### PR TITLE
Program.__setstate__: reinstate _program_executor_cache

### DIFF
--- a/loopy/program.py
+++ b/loopy/program.py
@@ -391,6 +391,12 @@ class Program(ImmutableRecord):
     def __str__(self):
         return self.root_kernel.__str__()
 
+
+    def __setstate__(self, state_obj):
+        super(Program, self).__setstate__(state_obj)
+
+        self._program_executor_cache = {}
+
 # }}}
 
 


### PR DESCRIPTION
Cherry-picked [this commit](https://github.com/inducer/loopy/commit/3d5efe6c4b3fea49419ebc6396e7cd6a3d31b089) from inducer's loopy