### PR TITLE
Firedrake fix float128andcomplex256

### DIFF
--- a/loopy/target/c/__init__.py
+++ b/loopy/target/c/__init__.py
@@ -495,7 +495,8 @@ class CMathCallable(ScalarCallable):
                     pass  # fabs
                 elif dtype in [np.float32, np.complex64]:
                     name = name + "f"  # fminf
-                elif dtype in [np.float128, np.complex256]:
+                elif ((hasattr(np, "float128") and dtype == np.float128) or
+                      (hasattr(np, "complex256") and dtype == np.complex256)):  # pylint:disable=no-member
                     name = name + "l"  # fminl
                 else:
                     raise LoopyTypeError("%s does not support type %s" % (name,
@@ -548,7 +549,8 @@ class CMathCallable(ScalarCallable):
                         pass  # fabs
                     elif dtype in [np.float32, np.complex64]:
                         name = name + "f"  # fminf
-                    elif dtype in [np.float128, np.complex256]:
+                    elif ((hasattr(np, "float128") and dtype == np.float128) or
+                          (hasattr(np, "complex256") and dtype == np.complex256)):  # pylint:disable=no-member
                         name = name + "l"  # fminl
                     else:
                         raise LoopyTypeError("%s does not support type %s"

--- a/loopy/target/c/c_execution.py
+++ b/loopy/target/c/c_execution.py
@@ -300,7 +300,30 @@ class CPlusPlusCompiler(CCompiler):
             library_dirs=library_dirs, defines=defines, source_suffix=source_suffix)
 
 
-class IDIToCDLL(object):
+# {{{ placeholder till ctypes fixes: bugs.python.org/issue16899
+
+class Complex64(ctypes.Structure):
+    _fields_ = [("real", ctypes.c_float), ("imag", ctypes.c_float)]
+
+
+class Complex128(ctypes.Structure):
+    _fields_ = [("real", ctypes.c_double), ("imag", ctypes.c_double)]
+
+
+class Complex256(ctypes.Structure):
+    _fields_ = [("real", ctypes.c_longdouble), ("imag", ctypes.c_longdouble)]
+
+_NUMPY_COMPLEX_TYPE_TO_CTYPE = {
+        np.complex64: Complex64,
+        np.complex128: Complex128,
+        }
+if hasattr(np, "complex256"):
+    _NUMPY_COMPLEX_TYPE_TO_CTYPE[np.complex256] = Complex256
+
+# }}}
+
+
+class IDIToCDLL:
     """
     A utility class that extracts arguement and return type info from a
     :class:`ImplementedDataInfo` in order to create a :class:`ctype.CDLL`
@@ -322,9 +345,12 @@ class IDIToCDLL(object):
 
     def _dtype_to_ctype(self, dtype, pointer=False):
         """Map NumPy dtype to equivalent ctypes type."""
-        typename = self.registry.dtype_to_ctype(dtype)
-        typename = {'unsigned': 'uint'}.get(typename, typename)
-        basetype = getattr(ctypes, 'c_' + typename)
+        if dtype.is_complex():
+            # complex ctypes aren't exposed
+            np_dtype = dtype.numpy_dtype.type
+            basetype = _NUMPY_COMPLEX_TYPE_TO_CTYPE[np_dtype]
+        else:
+            basetype = np.ctypeslib.as_ctypes_type(dtype)
         if pointer:
             return ctypes.POINTER(basetype)
         return basetype

--- a/loopy/target/c/c_execution.py
+++ b/loopy/target/c/c_execution.py
@@ -313,6 +313,7 @@ class Complex128(ctypes.Structure):
 class Complex256(ctypes.Structure):
     _fields_ = [("real", ctypes.c_longdouble), ("imag", ctypes.c_longdouble)]
 
+
 _NUMPY_COMPLEX_TYPE_TO_CTYPE = {
         np.complex64: Complex64,
         np.complex128: Complex128,


### PR DESCRIPTION
I was trying to cherry-pick https://github.com/inducer/loopy/pull/255, which got recently merged into loopy. It is fixing cases, where long types are not available on the architecture as mentioned in this issue https://github.com/inducer/loopy/issues/253.

Because loopy/main and firedrake/main have diverged in this file, I had to change the commit a bit in order to work with firedrake/loopy, but the logic is the same.

With this another change got picked up, which introduces _NUMPY_COMPLEX_TYPE_TO_CTYPE. I was not sure if I need to leave this in or not?